### PR TITLE
[추가] 사전 구장 자동 매칭 완료 시 해당 Game의 참가자들에게 문자메세지 전송

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### API KEY ###
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -30,11 +30,10 @@ dependencies {
 	testImplementation 'org.mockito:mockito-core:5.11.0'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	// 문자메세지 전송
+	implementation 'net.nurigo:sdk:4.3.0'
 }
-//
-//tasks.named('test') {
-//	useJUnitPlatform()
-//}
+
 test {
     useJUnitPlatform()
 }

--- a/src/main/java/PL_25/shuttleplay/Controller/AutoMatchController.java
+++ b/src/main/java/PL_25/shuttleplay/Controller/AutoMatchController.java
@@ -4,7 +4,9 @@ import PL_25.shuttleplay.Dto.Matching.AutoMatchRequest;
 import PL_25.shuttleplay.Entity.Game.Game;
 import PL_25.shuttleplay.Entity.Game.GameRoom;
 import PL_25.shuttleplay.Entity.Game.MatchQueueResponse;
+import PL_25.shuttleplay.Entity.User.NormalUser;
 import PL_25.shuttleplay.Service.AutoMatchService;
+import PL_25.shuttleplay.Service.MessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,7 @@ import java.util.Map;
 public class AutoMatchController {
 
     private final AutoMatchService autoMatchService;
+    private final MessageService messageService;
 
     @PostMapping("/queue/gym")
     public ResponseEntity<Map<String, Object>> registerGymQueue(@RequestParam Long userId,
@@ -70,6 +73,16 @@ public class AutoMatchController {
         if (game == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "매칭 조건에 맞는 사용자가 부족합니다.");
         }
+
+//        // 매칭 완료하여 Game 생성 시, 해당 userId 에게 문자 보내기
+//        for (NormalUser user : game.getParticipants()) {
+//            String to = user.getPhone();
+//            String text = "[셔틀플레이] " + user.getName() + "님! "
+//                    + game.getDate() + " " + game.getTime() + "에 "
+//                    + game.getLocation().getCourtName() + "에서 경기 매칭이 완료되었습니다!";
+//            messageService.sendMessage(to, text);
+//        }
+
         return ResponseEntity.ok(Map.of(
                 "message", "매칭 되었습니다.",
                 "gameId", game.getGameId(),
@@ -86,6 +99,7 @@ public class AutoMatchController {
         if (game == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "매칭 조건에 맞는 사용자가 부족합니다.");
         }
+
         return ResponseEntity.ok(Map.of(
                 "message", "매칭 되었습니다.",
                 "gameId", game.getGameId(),

--- a/src/main/java/PL_25/shuttleplay/Controller/MessageController.java
+++ b/src/main/java/PL_25/shuttleplay/Controller/MessageController.java
@@ -1,0 +1,38 @@
+package PL_25.shuttleplay.Controller;
+
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/api/message")
+public class MessageController {
+    final DefaultMessageService messageService;
+
+    // API KEY는 환경변수 타입으로 사용하도록 함
+    public MessageController(
+            @Value("${coolsms.api.key}") String apiKey,
+            @Value("${coolsms.api.secret}") String apiSecret
+    ) {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    }
+
+    // 단일 문자 보내기
+    @PostMapping("/send-one")
+    public SingleMessageSentResponse sendOne() {
+        Message message = new Message();
+        // 발신번호 및 수신번호는 반드시 01012345678 형태로 입력되어야 합니다.
+        message.setFrom("발신번호 입력");
+        message.setTo("수신번호 입력");
+        message.setText("한글 45자, 영자 90자 이하 입력되면 자동으로 SMS타입의 메시지가 추가됩니다.");
+
+        SingleMessageSentResponse response = this.messageService.sendOne(new SingleMessageSendingRequest(message));
+        System.out.println(response);
+
+        return response;
+    }
+}

--- a/src/main/java/PL_25/shuttleplay/Service/MessageService.java
+++ b/src/main/java/PL_25/shuttleplay/Service/MessageService.java
@@ -1,0 +1,40 @@
+package PL_25.shuttleplay.Service;
+
+import jakarta.annotation.PostConstruct;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MessageService {
+
+    @Value("${coolsms.api.key}")
+    private String apiKey;
+
+    @Value("${coolsms.api.secret}")
+    private String apiSecret;
+
+    @Value("${coolsms.sender.phone}")
+    private String senderPhone;
+
+    private DefaultMessageService messageService;
+
+    @PostConstruct
+    public void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    }
+
+    public void sendMessage(String to, String text) {
+        Message message = new Message();
+        message.setFrom(senderPhone);
+        message.setTo(to);
+        message.setText(text);
+
+        SingleMessageSentResponse response = messageService.sendOne(new SingleMessageSendingRequest(message));
+        System.out.println("문자 전송 결과: " + response);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,8 @@ spring.datasource.password=
 # auto create database table (option)
 #spring.jpa.hibernate.ddl-auto=create
 spring.jpa.hibernate.ddl-auto=update
+
+# CoolSMS API KEY (path)
+coolsms.api.key=${COOLSMS_API_KEY}
+coolsms.api.secret=${COOLSMS_API_SECRET}
+coolsms.sender.phone=${COOLSMS_SENDER_PHONE}


### PR DESCRIPTION
- 사전 구장 자동 매칭 완료 시 적용
- 기능 작동 확인 후 문자메세지 전송 호출 코드는 주석처리 해둠 (사용량 때문에)
- 기존 기능 영향 없는 것 확인